### PR TITLE
feat: parse args before running metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Code Coverage](https://codecov.io/gh/emazzotta/lighthouse-badges/branch/master/graph/badge.svg)](https://github.com/emazzotta/lighthouse-badges/actions)
 [![NPM downloads](https://img.shields.io/npm/dt/lighthouse-badges?color=blue)](https://www.npmjs.org/package/lighthouse-badges)
 [![NPM version](https://img.shields.io/npm/v/lighthouse-badges.svg)](https://www.npmjs.org/package/lighthouse-badges)
-[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://emanuelemazzotta.com/mit-license) 
+[![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://emanuelemazzotta.com/mit-license)
 
 # Lighthouse Badges
 
@@ -30,7 +30,7 @@ Ever wanted to brag about your sites's awesome Lighthouse performance? Then this
 ### Help
 
 ```txt
-usage: lighthouse-badges [-h] [-v] [-s] [-b {flat,flat-square,plastic,for-the-badge,popout,popout-square,social}] [-o OUTPUT_PATH] [-r] -u URL
+usage: lighthouse-badges [-h] [-v] [-s] [-b {flat,flat-square,plastic,for-the-badge,social}] [-o OUTPUT_PATH] [-r] -u URL
 
 Generate gh-badges (shields.io) based on lighthouse performance.
 
@@ -38,7 +38,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -s, --single-badge    Output only one single badge averaging all lighthouse categories' scores
-  -b {flat,flat-square,plastic,for-the-badge,popout,popout-square,social}, --badge-style {flat,flat-square,plastic,for-the-badge,popout,popout-square,social}
+  -b {flat,flat-square,plastic,for-the-badge,social}, --badge-style {flat,flat-square,plastic,for-the-badge,social}
                         Define look and feel for the badge
   -o OUTPUT_PATH, --output-path OUTPUT_PATH
                         Define output path for artifacts

--- a/src/argparser.js
+++ b/src/argparser.js
@@ -22,7 +22,7 @@ parser.add_argument('-s', '--single-badge', {
 parser.add_argument('-b', '--badge-style', {
   action: 'store',
   required: false,
-  choices: ['flat', 'flat-square', 'plastic', 'for-the-badge', 'popout', 'popout-square', 'social'],
+  choices: ['flat', 'flat-square', 'plastic', 'for-the-badge', 'social'],
   default: 'flat',
   help: 'Define look and feel for the badge',
 });

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const CLI_SPINNER = new CLI.Spinner('Running Lighthouse, please wait...', ['◜'
 const handleUserInput = async (spinner) => {
   try {
     spinner.start();
+    const parsedArgs = await parser.parse_args();
     let lighthouseParameters = { extends: 'lighthouse:default' };
     if (process.env.LIGHTHOUSE_BADGES_CONFIGURATION_PATH) {
       process.stdout.write(` LIGHTHOUSE_BADGES_CONFIGURATION_PATH: ${process.env.LIGHTHOUSE_BADGES_CONFIGURATION_PATH}\n`);
@@ -17,7 +18,7 @@ const handleUserInput = async (spinner) => {
       lighthouseParameters = JSON.parse(fileContent);
     }
     await processParameters(
-      await parser.parse_args(),
+      parsedArgs,
       calculateLighthouseMetrics,
       lighthouseParameters,
     );


### PR DESCRIPTION
## Short Description
When running this tool today and trying the `popout` style I got an error, so I took the liberty to file this PR and fix it.

Example of the error:
```sh
$ bunx lighthouse-badges --url "https://example.com" -s -o public/badges -b popout
  ◠ Running Lighthouse, please wait...Error: Field `style` must be one of (plastic,flat,flat-square,for-the-badge,social)
```

### Major Changes
- Parsing the args before running lighthouse metrics so the user get's a faster feedback.
- Removing the `popout` style option because `badge-maker` [doesn't accept](https://github.com/badges/shields/blob/master/badge-maker/index.d.ts#L6) it anymore.
